### PR TITLE
check for latitude and longitude before accessing them

### DIFF
--- a/utils/template_filters.py
+++ b/utils/template_filters.py
@@ -263,21 +263,24 @@ def has_place(note):
 def get_place(note):
     if note.get("location") and note["location"].get("type") == "Place":
         tag = note["location"]
-        lat = tag["latitude"]
-        lng = tag["longitude"]
-        out = ""
-        if tag.get("name"):
-            out += f"{tag['name']} "
+        if tag.get("latitude") and tag.get("longitude"):
+            lat = tag["latitude"]
+            lng = tag["longitude"]
+            out = ""
+            if tag.get("name"):
+                out += f"{tag['name']} "
 
-        out += (
-            '<span class="h-geo">'
-            f'<data class="p-latitude" value="{lat}"></data>'
-            f'<data class="p-longitude" value="{lng}"></data>'
-            f'<a href="https://www.openstreetmap.org/?mlat={lat}&mlon={lng}#map=16/{lat}/{lng}">{lat},{lng}</a>'
-            "</span>"
-        )
+            out += (
+                '<span class="h-geo">'
+                f'<data class="p-latitude" value="{lat}"></data>'
+                f'<data class="p-longitude" value="{lng}"></data>'
+                f'<a href="https://www.openstreetmap.org/?mlat={lat}&mlon={lng}#map=16/{lat}/{lng}">{lat},{lng}</a>'
+                "</span>"
+            )
 
-        return out
+            return out
+
+        return ""
 
     return ""
 


### PR DESCRIPTION
This checks latitude and longitude before accessing them, possibly preventing a 500 when accessing the stream where one post has the location field with an empty latitude/longitude field.

Sorry about the other pull request. I was basing it on the modifications I did on the templates.