### PR TITLE
Create config/local_actor_hash if not exists

### DIFF
--- a/utils/local_actor_cache.py
+++ b/utils/local_actor_cache.py
@@ -5,12 +5,13 @@ _CACHE_FILE = Path(__file__).parent.absolute() / ".." / "config" / "local_actor_
 
 def is_actor_updated(actor_hash: str) -> bool:
     actor_updated = False
-    if _CACHE_FILE.exists():
+    cache_exists = _CACHE_FILE.exists()
+    if cache_exists:
         current_hash = _CACHE_FILE.read_text()
         if actor_hash != current_hash:
             actor_updated = True
 
-    if actor_updated:
+    if actor_updated or not cache_exists:
         with _CACHE_FILE.open("w") as f:
             f.write(actor_hash)
 


### PR DESCRIPTION
After I change my profile in `config/me.yml` and start microblog.pub again, remote instances is not sometimes be updated the profile.
This is probably because `config/local_actor_hash` is not created, and `is_actor_updated()` always returns `False`.
(I tested on microblog.pub `fa9edb8` and Mastodon 3.1.1.)

Thank you.