### PR TITLE
push `/task/cache_actor_icon` at `Tasks.cache_actor_icon()`

### DIFF
--- a/core/tasks.py
+++ b/core/tasks.py
@@ -35,6 +35,8 @@ class Tasks:
         if MEDIA_CACHE.is_actor_icon_cached(icon_url):
             return None
 
+        p.push({"icon_url": icon_url, "actor_iri": actor_iri}, "/task/cache_actor_icon")
+
     @staticmethod
     def cache_emoji(url: str, iri: str) -> None:
         if MEDIA_CACHE.is_emoji_cached(iri):


### PR DESCRIPTION
Hello.

Microblog.pub sometimes writes error as follows:
```
[ERROR] cache not available for (Path)/50/Kind.ACTOR_ICON
```

This is probably because `Tasks.cache_actor_icon()` in `core/tasks.py` consults whether the file was cached or not, and  does not run `/tasks/cache_actor_icon`.

This patch added pushing `/tasks/cache_actor_icon` in `Tasks.cache_actor_icon()`.

Thank you.