### PR TITLE
Add CSRF Protection in POST /authorize_follow

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -639,6 +639,7 @@ def authorize_follow():
             )
         )
 
+    csrf.protect()
     actor = get_actor_url(request.form.get("profile"))
     if not actor:
         abort(500)


### PR DESCRIPTION
Hello.

This patch protects from CSRF attack on POST `/authorize_follow`. This protection prevents us from unexpected new follow.

(Sorry for sending multiple pull requests simultaneously)