### PR TITLE
Set Secure Flag On Cookie When Served As HTTPS

### DIFF
--- a/app.py
+++ b/app.py
@@ -93,6 +93,9 @@ app.register_blueprint(blueprints.indieauth.blueprint)
 app.register_blueprint(blueprints.tasks.blueprint)
 app.register_blueprint(blueprints.well_known.blueprint)
 app.config.update(WTF_CSRF_CHECK_DEFAULT=False)
+
+app.config.update(SESSION_COOKIE_SECURE=True if config.SCHEME == "https" else False)
+
 csrf.init_app(app)
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Hello.

This pull request adds secure flag on session cookie to prevent from sending session information on HTTP, when the site enables HTTPS.

See also: [Flask Security Considerations#Set-Cookie options](https://flask.palletsprojects.com/en/1.1.x/security/#set-cookie-options)

Thank you.