### PR TITLE
[WIP] Send security-related headers using flask-tailsman

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,6 +29,7 @@ from little_boxes.errors import Error
 from little_boxes.httpsig import verify_request
 from little_boxes.webfinger import get_remote_follow_template
 from werkzeug.exceptions import InternalServerError
+from flask_talisman import Talisman
 
 import blueprints.admin
 import blueprints.indieauth
@@ -93,7 +94,21 @@ app.register_blueprint(blueprints.indieauth.blueprint)
 app.register_blueprint(blueprints.tasks.blueprint)
 app.register_blueprint(blueprints.well_known.blueprint)
 app.config.update(WTF_CSRF_CHECK_DEFAULT=False)
+app.config.update(SESSION_COOKIE_SECURE=True if config.SCHEME == "https" else False)
+
+csp = {
+    "default-src": "'self'",
+    "script-src": "'self'",
+    "style-src-attr": "'unsafe-inline'",
+}
+
 csrf.init_app(app)
+talisman = Talisman(
+    app,
+    content_security_policy=csp,
+    force_https=False,
+    content_security_policy_nonce_in=["script-src", "style-src"],
+)
 
 logger = logging.getLogger(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ pillow
 emoji-unicode
 html5lib
 Pygments
+flask-talisman

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -12,7 +12,7 @@
 {% if not request.args.get("older_than") and not request.args.get("previous_than") %}<link rel="canonical" href="https://{{ config.DOMAIN }}{{ request.path }}">{% endif %}
 {% block links %}{% endblock %}
 {% if config.THEME_COLOR %}<meta name="theme-color" content="{{ config.THEME_COLOR }}">{% endif %}
-<style>{{ config.CSS | safe }}
+<style nonce="{{ csp_nonce() }}">{{ config.CSS | safe }}
 .icon { color: #555; }
 .emoji {
     width: 20px;

--- a/templates/login.html
+++ b/templates/login.html
@@ -2,7 +2,7 @@
 {% import 'utils.html' as utils %}
 {% block title %}Login - {{ config.NAME }}{% endblock %}
 {% block header %}
-<style>
+<style nonce="{{ csp_nonce() }}">
 #login-container {
 height: 90%;
 display: grid;
@@ -28,7 +28,7 @@ display:inline;
 
 </div>
 {% if u2f_enabled %}
-<script>
+<script nonce="{{ csp_nonce() }}">
 var p = {{ payload | tojson }};
 if (p) {
 u2f.sign(p.appId, p.challenge, p.registeredKeys, function(resp) {

--- a/templates/new.html
+++ b/templates/new.html
@@ -90,7 +90,7 @@
 
 </div>
 </div>
-<script>
+<script nonce="{{ csp_nonce() }}">
 // The new post textarea
 var ta = document.getElementsByTagName("textarea")[0];
 // Helper for inserting text (emojis) in the textarea

--- a/templates/u2f.html
+++ b/templates/u2f.html
@@ -12,7 +12,7 @@
 </form>
 
 </div>
-<script>
+<script nonce="{{ csp_nonce() }}">
 var p= {{ payload | tojson }};
 //setTimeout(function() {
 u2f.register(p.appId, p.registerRequests, p.registeredKeys, function(resp) {


### PR DESCRIPTION
Hello.

I'm interested in using [Flask-Tailsman](https://github.com/GoogleCloudPlatform/flask-talisman) introduced in [Security Considerations: Flask Documentation](https://flask.palletsprojects.com/en/1.1.x/security/#security-headers) and supporting security-related response headers like [Content Security Policy](https://csp.withgoogle.com/docs/index.html).

Current implementation status is as follows. I today began to test on [my instance](https://mblg.hiromi-mi.jp).

- [x] Implementation: apply Tailsman
- [x] Implementation: add nonce in inline CSS/JavaScript
- [x] Test: authentification without U2F
- [x] Test: sending new posts
- [x] Test: receiving posts
- [ ] Test: authentification with U2F
- [ ] Test: federation
- [ ] (Optional) make Content Security Policy stricter

(Of course) please feel free to comment any ideas, suggestions and questions.

Thank you!